### PR TITLE
add specified yearType

### DIFF
--- a/R/calc_magnifSeven.r
+++ b/R/calc_magnifSeven.r
@@ -15,7 +15,7 @@
 calc_magnifSeven<-function(x,yearType = "water",digits=3)  {
         
         #Check data inputs
-        x <- validate_data(x,yearType)
+        x <- validate_data(x,yearType = yearType)
         
         #calculate some stuff for use later
         x$month_val <- lubridate::month(x$date)


### PR DESCRIPTION
calc_magnifSeven was throwing an error when using `yearType="calendar"` .  The default, "water" was being passed to validate_data. 