### PR TITLE
175+177 special cases

### DIFF
--- a/R/calc_frequencyHigh.R
+++ b/R/calc_frequencyHigh.R
@@ -125,7 +125,8 @@ calc_frequencyHigh <- function(x,yearType = "water",digits=3,pref="mean",floodTh
                                                       type="high")
                                    }
         )
-        yearlyCounts <- na.omit(yearlyCounts)
+        #Replace NAs with 0 so years with 0 events are counted
+        yearlyCounts$event[is.na(yearlyCounts$event)] <- 0
         
         #Get number of events each year
         yearlyCounts <- dplyr::summarize(dplyr::group_by(yearlyCounts,year_val),
@@ -235,7 +236,8 @@ calc_frequencyHigh <- function(x,yearType = "water",digits=3,pref="mean",floodTh
                                                       type="high")
                                    }
         )
-        yearlyCounts <- na.omit(yearlyCounts)
+        #Replace NAs with 0 so years with 0 events are counted
+        yearlyCounts$event[is.na(yearlyCounts$event)] <- 0
         
         #Get number of events each year
         yearlyCounts <- dplyr::summarize(dplyr::group_by(yearlyCounts,year_val),

--- a/R/find_changeEvents.R
+++ b/R/find_changeEvents.R
@@ -4,6 +4,7 @@
 #' is greater or less than the preceding value of flow, and classifies the flow vector into events. An event
 #' is defined as when a change in flow from one day to the next changes direction, e.g. rising limb to falling limb. 
 #' If there is no change in flow from one day to the next it is considered part of the preceding event.
+#' If there is no change in flow for the whole timeseries, the timeseries is assigned event 0.
 #' 
 #' @param x A vector of flow values, should be sorted chronologically.
 #' @return A dataframe with columns "flow" and "event"
@@ -21,33 +22,37 @@ find_changeEvents <- function(x) {
         changeDir <- sign(diffDays)
         changeDir[changeDir==0] <- NA
         
-        changeDir <- imputeTS::na.locf(changeDir, na.remaining="rev")
-        
-        runLengths <- rle(changeDir)
-        
-        runLengths <- data.frame(lengths = runLengths$lengths,
-                                 values = runLengths$values,
-                                 eventNum = NA)
-        
-        #Make sequence of numbers to number events
-        events <- seq_along(na.omit(runLengths$values))
-        
-        #Number events
-        runLengths$eventNum[!is.na(runLengths$values)] <- events
-        eventVector <- rep.int(runLengths$eventNum,runLengths$lengths)
-
-        #substract 1 event from event vector to make it start at 0 since there is no knowledge of the
-        #flow before the start of the record
-        eventVector <- eventVector - 1
-        
-        #Fill in first dropped entry with a 0 event to max length of flow
-        eventVector <- c(0,eventVector)
-        
-        
-        changeEvents <- data.frame(flow=x,
-                                   event=eventVector)
+        if(all(is.na(changeDir))){
+                #No changes in this timeseries
+                changeEvents <- data.frame(flow = x,
+                                           event = 0)
+        }else{
+                changeDir <- imputeTS::na.locf(changeDir, na.remaining="rev")
+                
+                runLengths <- rle(changeDir)
+                
+                runLengths <- data.frame(lengths = runLengths$lengths,
+                                         values = runLengths$values,
+                                         eventNum = NA)
+                
+                #Make sequence of numbers to number events
+                events <- seq_along(na.omit(runLengths$values))
+                
+                #Number events
+                runLengths$eventNum[!is.na(runLengths$values)] <- events
+                eventVector <- rep.int(runLengths$eventNum,runLengths$lengths)
+                
+                #substract 1 event from event vector to make it start at 0 
+                #since there is no knowledge of the flow before the start of the record
+                eventVector <- eventVector - 1
+                
+                #Fill in first dropped entry with a 0 event to max length of flow
+                eventVector <- c(0,eventVector)
+                
+                
+                changeEvents <- data.frame(flow = x,
+                                           event = eventVector)  
+        }
         
         return(changeEvents)
 }
-
-        


### PR DESCRIPTION
Addresses #175 by counting years with no events and having 0 events for FH5 and FH10. This makes FH5 and FH10 consistent with how all other FH metrics handle years with no events. The issue's comment that FH5 and FH1 are now the same is incorrect because FH1 uses a different quantile. FH1 and FH9 are actually identical.

Addresses #177 by assigning event number 0 to timeseries that have no changes in flow. The output of this function is currently only used to take the max(event), which returns 0 for these cases.